### PR TITLE
Fix undo/redo array mutation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,19 +10,21 @@ function App() {
     setPoints([...points, { xAxis: e.clientX, yAxis: e.clientY }])
   }
 
-  const handleUndo = (e) => {
-    const actualPoints = points;
-    const lastPoint = actualPoints.pop();
+  const handleUndo = () => {
+    const updatedPoints = points.slice();
+    const lastPoint = updatedPoints.pop();
     if (lastPoint) {
-      setUndoPoints([...undoPoints, lastPoint])
-      setPoints(actualPoints);
+      setUndoPoints(prev => [...prev, lastPoint]);
+      setPoints(updatedPoints);
     }
   }
 
-  const handleRedo = (e) => {
-    const lastPointRemoved = undoPoints.pop();
-    if (lastPointRemoved) {
-      setPoints([...points, lastPointRemoved]);
+  const handleRedo = () => {
+    const updatedUndo = undoPoints.slice();
+    const lastPoint = updatedUndo.pop();
+    if (lastPoint) {
+      setUndoPoints(updatedUndo);
+      setPoints(prev => [...prev, lastPoint]);
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent direct mutation of points and undoPoints
- copy the arrays first when undoing or redoing

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fc0311a4832f9fd18e2463600036