### PR TITLE
Fix undo stack after clicks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ function App() {
 
   const handleClick = (e) => {
     setPoints([...points, { xAxis: e.clientX, yAxis: e.clientY }])
+    setUndoPoints([])
   }
 
   const handleUndo = (e) => {


### PR DESCRIPTION
## Summary
- clear redo stack when a new dot is added

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fc04a514832f979627a521993e42